### PR TITLE
Bump alpine from 3.20 to 3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20
+FROM alpine:3.22
 
 # 'nobody' user in alpine
 USER 65534


### PR DESCRIPTION
Bumps alpine from 3.20 to 3.22.

---
updated-dependencies:
- dependency-name: alpine dependency-version: '3.22' dependency-type: direct:production update-type: version-update:semver-minor ...


This PR fixes #

## Checklist
* [ ] I have signed the CLA
* [ ] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

### What changes did you make?

### What alternative solution should we consider, if any?

